### PR TITLE
fix the multiple dropdown filtering

### DIFF
--- a/app/controllers/subsidy/applications.js
+++ b/app/controllers/subsidy/applications.js
@@ -1,7 +1,5 @@
 import Controller from '@ember/controller';
-import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import { typeOf } from '@ember/utils';
 
 export default class SubsidyApplicationsController extends Controller {
   @service router;

--- a/app/routes/subsidy/applications.js
+++ b/app/routes/subsidy/applications.js
@@ -74,12 +74,14 @@ export default class SearchSubmissionsRoute extends Route {
 
     // Override the standard params.subsidiestatus filtering by regexing for the id and using that instead
     // Using the id instead of the uri, because that's the only way currently to pass multiple values comma seperated
-    if (params.subsidieStatus){
+    if (params.subsidieStatus) {
       const subsidieStatusUriList = params.subsidieStatus.split(',');
-      const subsidieStatusIdList = subsidieStatusUriList.map(p => {
-        const parts = p.split('/');
-        return parts[parts.length - 1];
-      }).join(',');
+      const subsidieStatusIdList = subsidieStatusUriList
+        .map((p) => {
+          const parts = p.split('/');
+          return parts[parts.length - 1];
+        })
+        .join(',');
       query['filter[status][:id:]'] = subsidieStatusIdList;
     }
 

--- a/app/routes/subsidy/applications.js
+++ b/app/routes/subsidy/applications.js
@@ -72,8 +72,16 @@ export default class SearchSubmissionsRoute extends Route {
 
     if (params.aanvraagDatum) query['filter[modified]'] = params.aanvraagDatum;
 
-    if (params.subsidieStatus)
-      query['filter[status][:uri:]'] = params.subsidieStatus;
+    // Override the standard params.subsidiestatus filtering by regexing for the id and using that instead
+    // Using the id instead of the uri, because that's the only way currently to pass multiple values comma seperated
+    if (params.subsidieStatus){
+      const subsidieStatusUriList = params.subsidieStatus.split(',');
+      const subsidieStatusIdList = subsidieStatusUriList.map(p => {
+        const parts = p.split('/');
+        return parts[parts.length - 1];
+      }).join(',');
+      query['filter[status][:id:]'] = subsidieStatusIdList;
+    }
 
     this.lastParams.commit();
 


### PR DESCRIPTION
 ## ID
 DGS-46

 ## Description

Fix the issue where selecting multiple dropdown items showed nothing. I used the id of the dropdown items, instead of the uri. Since the id is currently the only way we can pass multiple values comma seperated.

 ## Type of change

 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Other

 ## How to test

Visist the subsidiedatabank and click multiple subsidy statuses and see that it filters successfully.
