### PR TITLE
feature: add the 'oproep' subsidyMeasureOfferSeries title

### DIFF
--- a/app/components/search-table/resource/row.hbs
+++ b/app/components/search-table/resource/row.hbs
@@ -1,5 +1,10 @@
 <td>
   {{@consumption.subsidyMeasureOffer.title}}
+  {{#if @consumption.subsidyApplicationFlow.subsidyMeasureOfferSeries.title}}
+    <AuHelpText @skin="secondary" class="au-u-margin-top-none">
+      ({{@consumption.subsidyApplicationFlow.subsidyMeasureOfferSeries.title}})
+    </AuHelpText>
+  {{/if}}
 </td>
 <td>
   {{!-- template-lint-disable no-array-prototype-extensions --}}

--- a/app/components/search-table/resource/row.hbs
+++ b/app/components/search-table/resource/row.hbs
@@ -1,8 +1,8 @@
 <td>
   {{@consumption.subsidyMeasureOffer.title}}
-  {{#if @consumption.subsidyApplicationFlow.subsidyMeasureOfferSeries.title}}
+  {{#if @consumption.subsidyApplicationFlow.subsidyMeasureOfferSeries.label}}
     <AuHelpText @skin="secondary" class="au-u-margin-top-none">
-      ({{@consumption.subsidyApplicationFlow.subsidyMeasureOfferSeries.title}})
+      {{@consumption.subsidyApplicationFlow.subsidyMeasureOfferSeries.label}}
     </AuHelpText>
   {{/if}}
 </td>


### PR DESCRIPTION
## ID
DGS-77

 ## Description

Add the 'oproep' subsidyMeasureOfferSeries title as a subtitle underneath the subsidiemaatregel.

 ## Type of change

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Other

 ## How to test

Visit the subsidiedatabank and see the newly added 'oproep' subtitles in the first column. 