### PR TITLE
feature: introduce feature flags with detailview

### DIFF
--- a/app/components/search-table/resource/row.hbs
+++ b/app/components/search-table/resource/row.hbs
@@ -1,7 +1,11 @@
 <td>
-  <LinkTo @route="subsidy.detail" @model={{@consumption.id}} class="au-c-link">
+  {{#if this.features.detailView}}
+    <LinkTo @route="subsidy.detail" @model={{@consumption.id}} class="au-c-link">
+      {{@consumption.subsidyMeasureOffer.title}}
+    </LinkTo>
+  {{else}}
     {{@consumption.subsidyMeasureOffer.title}}
-  </LinkTo>
+  {{/if}}
 </td>
 <td>
   {{! template-lint-disable no-array-prototype-extensions }}

--- a/app/components/search-table/resource/row.js
+++ b/app/components/search-table/resource/row.js
@@ -1,0 +1,6 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class RowComponent extends Component {
+  @service features;
+}

--- a/app/routes/subsidy/detail.js
+++ b/app/routes/subsidy/detail.js
@@ -21,11 +21,19 @@ import FinancingTotalsComponent from 'frontend-subsidiedatabank/components/rdf-f
 export default class SubsidyDetailRoute extends Route {
   @service store;
   @service currentSession;
+  @service features;
 
   constructor() {
     super(...arguments);
 
     this.registerTableFields();
+  }
+
+  // Make the detailview unreachable with the feature flag
+  beforeModel() {
+    if (!this.features.get('detailView')) {
+      this.transitionTo('subsidy.applications');
+    }
   }
 
   async model({ id: consumptionID }) {

--- a/app/routes/subsidy/detail.js
+++ b/app/routes/subsidy/detail.js
@@ -21,19 +21,11 @@ import FinancingTotalsComponent from 'frontend-subsidiedatabank/components/rdf-f
 export default class SubsidyDetailRoute extends Route {
   @service store;
   @service currentSession;
-  @service features;
 
   constructor() {
     super(...arguments);
 
     this.registerTableFields();
-  }
-
-  // Make the detailview unreachable with the feature flag
-  beforeModel() {
-    if (!this.features.get('detailView')) {
-      this.transitionTo('subsidy.applications');
-    }
   }
 
   async model({ id: consumptionID }) {

--- a/config/environment.js
+++ b/config/environment.js
@@ -16,7 +16,7 @@ module.exports = function (environment) {
 
     // Feature flags for the application to enable/disable certain features
     featureFlags: {
-      detailView: true,
+      detailView: false,
     },
 
     APP: {
@@ -35,11 +35,7 @@ module.exports = function (environment) {
   };
 
   if (environment === 'development') {
-    // ENV.APP.LOG_RESOLVER = true;
-    // ENV.APP.LOG_ACTIVE_GENERATION = true;
-    // ENV.APP.LOG_TRANSITIONS = true;
-    // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
-    // ENV.APP.LOG_VIEW_LOOKUPS = true;
+    ENV.featureFlags['detailView'] = true; 
   }
 
   if (environment === 'test') {
@@ -55,8 +51,6 @@ module.exports = function (environment) {
   }
 
   if (environment === 'production') {
-    // here you can enable a production-specific feature
-    ENV.featureFlags['detailView'] = false; // make sure to disable the detailsView in production for now
   }
 
   return ENV;

--- a/config/environment.js
+++ b/config/environment.js
@@ -14,6 +14,11 @@ module.exports = function (environment) {
       },
     },
 
+    // Feature flags for the application to enable/disable certain features
+    featureFlags: {
+      detailView: true,
+    },
+
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
@@ -51,6 +56,7 @@ module.exports = function (environment) {
 
   if (environment === 'production') {
     // here you can enable a production-specific feature
+    ENV.featureFlags['detailView'] = false; // make sure to disable the detailsView in production for now
   }
 
   return ENV;

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "ember-cli-terser": "^4.0.2",
         "ember-concurrency": "^3.1.0",
         "ember-data": "~4.11.3",
+        "ember-feature-flags": "^6.0.0",
         "ember-fetch": "^8.1.2",
         "ember-load-initializers": "^2.1.2",
         "ember-modifier": "^4.1.0",
@@ -16316,6 +16317,18 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "node_modules/ember-feature-flags": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ember-feature-flags/-/ember-feature-flags-6.0.0.tgz",
+      "integrity": "sha512-CcKpQ0NI/AMkYcP/4obqfDrzFlLqFngabFUfmAlQNnCic5cz51nlLY9MzYRtbop0+1iyegM4XHJFE4Awlji/1g==",
+      "dev": true,
+      "dependencies": {
+        "ember-cli-babel": "^7.11.1"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
       }
     },
     "node_modules/ember-fetch": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "ember-cli-terser": "^4.0.2",
     "ember-concurrency": "^3.1.0",
     "ember-data": "~4.11.3",
+    "ember-feature-flags": "^6.0.0",
     "ember-fetch": "^8.1.2",
     "ember-load-initializers": "^2.1.2",
     "ember-modifier": "^4.1.0",


### PR DESCRIPTION
## ID
 DGS-96

 ## Description
Introduce feature flags to subsidieDB, starting off with the detailview. So we can enable detailviews during dev, but disable it on production (for now) with the featureFlag.

 ## Type of change

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Other

 ## How to test

Run the frontend and backend. Toggle the `detailView` value in `frontend-subsidiedatabank/config/environement.js`. And verify that the subsidies become clickable to their detailviews.