### PR TITLE
Task: remove oproepLabel featureflag

### DIFF
--- a/app/components/search-table/resource/row.hbs
+++ b/app/components/search-table/resource/row.hbs
@@ -8,13 +8,10 @@
       {{@consumption.subsidyMeasureOffer.title}}
   {{/if}}
 
-  {{!-- FEATURE-FLAG --}}
-  {{#if this.features.oproepLabel }}
-    {{#if @consumption.subsidyApplicationFlow.subsidyMeasureOfferSeries.label }}
-      <AuHelpText @skin="secondary" class="au-u-margin-top-none">
-        {{@consumption.subsidyApplicationFlow.subsidyMeasureOfferSeries.label}}
-      </AuHelpText>
-    {{/if}}
+  {{#if @consumption.subsidyApplicationFlow.subsidyMeasureOfferSeries.label }}
+    <AuHelpText @skin="secondary" class="au-u-margin-top-none">
+      {{@consumption.subsidyApplicationFlow.subsidyMeasureOfferSeries.label}}
+    </AuHelpText>
   {{/if}}
 </td>
 <td>

--- a/config/environment.js
+++ b/config/environment.js
@@ -21,7 +21,6 @@ module.exports = function (environment) {
     // Feature flags for the application to enable/disable certain features
     featureFlags: {
       detailView: false,
-      oproepLabel: false,
     },
     // Analytics
     'ember-plausible': {
@@ -41,7 +40,6 @@ module.exports = function (environment) {
 
   if (environment === 'development') {
     ENV.featureFlags['detailView'] = true;
-    ENV.featureFlags['oproepLabel'] = true;
   }
 
   if (environment === 'test') {


### PR DESCRIPTION
 ## Description

Since all the oproepen should be visible now with the fix getting deployed to Loket production, quick PR to remove the oproepLabel featureflag to release it and show it by default.

 ## Type of change

 - [ ] Bug fix
 - [ ] New feature
 - [ ] Breaking change
 - [x] Other

 ## How to test

 Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
