### PR TITLE
Fix/change help button link

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -8,7 +8,7 @@
   >
     <li class="au-c-list-horizontal__item">
       <AuLinkExternal
-        href="https://app.gitbook.com/o/-MP9Yduzf5xu7wIebqPG/s/p08BFkLpjrEXuesB8iYQ/"
+        href="https://abb-vlaanderen.gitbook.io/handleiding-subsidiedatabank/"
         @icon="question-circle"
         @skin="secondary"
       >

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -8,7 +8,7 @@
   >
     <li class="au-c-list-horizontal__item">
       <AuLinkExternal
-        href="https://abb-vlaanderen.gitbook.io/informatie-lpdc/"
+        href="https://app.gitbook.com/o/-MP9Yduzf5xu7wIebqPG/s/p08BFkLpjrEXuesB8iYQ/"
         @icon="question-circle"
         @skin="secondary"
       >


### PR DESCRIPTION
## ID
 DGS-114

 ## Description

Update the help button URL.

 ## Type of change

 - [x] Bug fix
 - [ ] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

 The help button now redirects to https://abb-vlaanderen.gitbook.io/handleiding-subsidiedatabank/
