### PR TITLE
Fix: table count

### DIFF
--- a/app/controllers/subsidy/applications.js
+++ b/app/controllers/subsidy/applications.js
@@ -6,6 +6,6 @@ export default class SubsidyApplicationsController extends Controller {
   @service currentSession;
 
   page = 0;
-  size = 15;
+  size = 20;
   sort = '-modified';
 }


### PR DESCRIPTION
## ID
 DGS-0001

 ## Description

Fixed the table count displaying the amount of subsidies per page

 ## Type of change

 - [x] Bug fix
 - [ ] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

Run `ember serve --proxy https://subsidiedatabank.abb.lblod.info` and verify the table count now displays '0-20', '21-40'
