### PR TITLE
fix: broken zip-download

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -8,6 +8,9 @@ module.exports = function (defaults) {
       dutchDatePickerLocalization: true,
       disableWormholeElement: true,
     },
+    'ember-test-selectors': {
+      strip: false,
+    },
     'ember-simple-auth': {
       useSessionSetupMethod: true,
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "frontend-subsidiedatabank",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "devDependencies": {
         "@appuniversum/ember-appuniversum": "^2.18.0",


### PR DESCRIPTION
## ID
 DGS-341

 ## Description

This PR fixes the zip-download that was broken when built to production, because by default the test-selectors are stripped. 

 ## Type of change

 - [x] Bug fix
 - [ ] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

Open a subsidy on QA and try to download attachments as zip (if there are any attachments).
