### PR TITLE
Add info box for newly created submissions

### DIFF
--- a/app/controllers/subsidy/detail/step/detail.js
+++ b/app/controllers/subsidy/detail/step/detail.js
@@ -121,6 +121,15 @@ export default class SubsidyDetailStepDetailController extends Controller {
     return this.model.step.get('deadline').content;
   }
 
+  get isConsumptionFromToday() {
+    const today = new Date();
+    return (
+      this.consumption.created.getFullYear() === today.getFullYear() &&
+      this.consumption.created.getMonth() === today.getMonth() &&
+      this.consumption.created.getDate() === today.getDate()
+    );
+  }
+
   // TODO what is this?
   @action
   registerObserver() {

--- a/app/templates/subsidy/detail/step/detail.hbs
+++ b/app/templates/subsidy/detail/step/detail.hbs
@@ -15,6 +15,17 @@
     {{/if}}
   </p>
 
+  {{#if this.isConsumptionFromToday}}
+  <div class="au-o-box au-u-max-width-medium">
+    <AuAlert @icon="info-circle" @title="De subsidiestap is vandaag ingediend" @skin="info" @size="small">
+      <p>Subsidies worden dagelijks gesynchroniseerd met de subsidiedatabank. Als er op dezelfde dag nog wijzigingen
+        zijn gebeurd, kan de informatie tijdelijk onvolledig of verouderd zijn.
+      </p>
+    </AuAlert>
+  </div>
+  {{/if}}
+
+
   {{!-- Form can be found but has been skipped --}}
   {{#if (and this.isPreviousStep (not this.submitted)) }}
   <div class="au-o-box au-u-max-width-medium">


### PR DESCRIPTION
## ID
DGS-526

 ## Description

Add an info box for subsidies that have been created today, saying that these subsidies can be incomplete or outdated.

 ## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

Create a new subsidy on subsidiepunt and wait for the sync, or force set the day of today to one of the subsidies that's already in subsidiedatabank: `const today = new Date('05-05-2025');` https://github.com/lblod/frontend-subsidiedatabank/pull/35/files#diff-1c83f3e4c692a192d10f2891d0f76a6d83ad08631cb7791ba3b718afe86d9f05R125
