### PR TITLE
[DGS-614] Show not-started message for last steps without a form

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -15,6 +15,7 @@ Router.map(function () {
       this.route('step', { path: '/steps/:step_id' }, function () {
         this.route('detail', { path: '/forms/:form_id' });
         this.route('skipped');
+        this.route('not-started');
       });
     });
   });

--- a/app/routes/subsidy/detail/step/index.js
+++ b/app/routes/subsidy/detail/step/index.js
@@ -15,13 +15,14 @@ export default class SubsidyDetailStepIndexRoute extends Route {
         'subsidy-measure-consumption': {
           ':id:': consumption.id,
         },
-      },
+      }
     });
 
     /**
      * NOTE: for now hardcoded with the assumption "one step has only one form"
      */
     const form = forms[0];
+
     if (form) {
       return this.router.replaceWith(
         'subsidy.detail.step.detail',
@@ -30,6 +31,21 @@ export default class SubsidyDetailStepIndexRoute extends Route {
         form.id,
       );
     } else {
+      const applicationFlow = await consumption.subsidyApplicationFlow
+      const definedSteps = await applicationFlow.get('definedSteps')
+      const lastStep = definedSteps.length - 1;
+
+      const isLastStep =
+        step.get('order') === lastStep;
+
+      if (isLastStep) {
+        return this.router.replaceWith(
+          'subsidy.detail.step.not-started',
+          consumption.id,
+          step.id,
+        );
+      }
+
       // Form not found => step was skipped in subsidiepunt
       return this.router.replaceWith(
         'subsidy.detail.step.skipped',

--- a/app/routes/subsidy/detail/step/not-started.js
+++ b/app/routes/subsidy/detail/step/not-started.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class SubsidyDetailStepNotStartedRoute extends Route {}

--- a/app/templates/subsidy/detail/step/not-started.hbs
+++ b/app/templates/subsidy/detail/step/not-started.hbs
@@ -1,0 +1,7 @@
+<div id="subsidyParent" class="au-c-body-container au-c-body-container--scroll">
+  <div class="au-o-box au-u-max-width-medium">
+    <AuAlert @title="Deze stap werd nog niet gestart." @skin="info" @icon="circle-step-1" @closable={{false}}>
+      <p>Deze stap is actief maar werd nog niet gestart door de gebruiker.</p>
+    </AuAlert>
+  </div>
+</div>


### PR DESCRIPTION
Specifically for last steps that dont have  a form yet

## ID
[DGS-614](https://binnenland.atlassian.net/browse/DGS-614)

 ## Description

Usually when no "form" is found for a step it means the step was skipped. We cover this case, they get a message saying "step was skipped". But an exception to this case is if this happens to the last step. In this case it means that the user hasnt started the form yet. So for steps without a form but those that are last steps we need to show a new message "not-started"

 ## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

 Setup with QA data and go to this page: http://localhost:4200/subsidy/692857BD3078C8BBD5BF0FE0/steps/9aa066f6-76fc-476c-a10f-6fb909b19248/not-started
 
 You should see the message "not-started"